### PR TITLE
update setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You will need:
 
 
 Next you need to obtain a set of credentials from Amazon to use the Alexa Voice service, login at http://developer.amazon.com and Goto Alexa then Alexa Voice Service
-You need to create a new product type as a Device, for the ID use something like AlexaCHIP, create a new security profile and under the web settings allowed origins put http://localhost:5000 and as a return URL put http://localhost:5000/code you can also create URLs replacing localhost with the IP of your Pi  eg http://192.168.1.123:5000
+You need to create a new product type as a Device, for the ID use something like AlexaPi, create a new security profile and under the web settings allowed origins put http://localhost:5000 and as a return URL put http://localhost:5000/code you can also create URLs replacing localhost with the IP of your Pi  eg http://192.168.1.123:5000
 Make a note of these credentials you will be asked for them during the install process
 
 ### Installation

--- a/main.py
+++ b/main.py
@@ -77,7 +77,7 @@ def alexa():
        		"format": "audio/L16; rate=16000; channels=1"
    		}
 	}
-	with open('recording.wav') as inf:
+	with open(path+'recording.wav') as inf:
 		files = [
 				('file', ('request', json.dumps(d), 'application/json; charset=UTF-8')),
 				('file', ('audio', inf, 'audio/L16; rate=16000; channels=1'))
@@ -91,7 +91,7 @@ def alexa():
 		for d in data:
 			if (len(d) >= 1024):
 				audio = d.split('\r\n\r\n')[1].rstrip('--')
-		with open("response.mp3", 'wb') as f:
+		with open(path+"response.mp3", 'wb') as f:
 			f.write(audio)
 		GPIO.output(25, GPIO.LOW)
 		os.system('mpg123 -q {}1sec.mp3 {}response.mp3'.format(path, path))

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 apt-get update
-apt-get install  libasound2-dev memcached python-pip mpg123 python-alsaaudio
+apt-get install  libasound2-dev memcached python-pip mpg123 python-alsaaudio python-aubio pip-install
 pip install -r requirements.txt
 cp initd_alexa.sh /etc/init.d/alexa
 cd /etc/rc5.d

--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,7 @@ echo "Enter your Security Client Secret:"
 read secret
 echo Client_Secret = \"$secret\" >> creds.py
 
-ip=$(ifconfig eth0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1`)
+ip=$(ifconfig eth0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1)
 echo "Open http://$ip:5000"
 python ./auth_web.py 
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,14 @@
 #! /bin/bash
 
+baselocation = "{$PWD}"
 apt-get update
-apt-get install  libasound2-dev memcached python-pip mpg123 python-alsaaudio python-aubio pip-install
+apt-get install  libasound2-dev memcached python-pip mpg123 python-alsaaudio python-aubio
 pip install -r requirements.txt
 cp initd_alexa.sh /etc/init.d/alexa
 cd /etc/rc5.d
 ln -s ../init.d/alexa S99alexa
 touch /var/log/alexa.log
-
+cd $baselocation
 echo "Enter your ProductID:"
 read productid
 echo ProductID = \"$productid\" >> creds.py
@@ -28,9 +29,9 @@ echo "Enter your Security Client Secret:"
 read secret
 echo Client_Secret = \"$secret\" >> creds.py
 
-ip = `ifconfig eth0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1`
-python ./auth_web.py 
+ip=$(ifconfig eth0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1`)
 echo "Open http://$ip:5000"
+python ./auth_web.py 
 
 echo "You can now reboot"
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 baselocation = "{$PWD}"
 apt-get update
-apt-get install  libasound2-dev memcached python-pip mpg123 python-alsaaudio python-aubio
+apt-get install libasound2-dev memcached python-pip mpg123 python-alsaaudio python-aubio
 pip install -r requirements.txt
 cp initd_alexa.sh /etc/init.d/alexa
 cd /etc/rc5.d


### PR DESCRIPTION
In setup.sh
change the line 
`pip install -r requirements.txt`
to
`pip2 install -r requirements.txt`

As wsgiref only works with python 2 and as soon as the user install python 3 and upgrade pip, the pip automatically points to python 3 rather than python 2. This creates error while install wsgiref library.
pip2 will install the dependencies in python 2's packages folder